### PR TITLE
fix: Nix環境設定にGitを追加

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -11,6 +11,9 @@
     pkgs.nh
     pkgs.nix-output-monitor
 
+    # Git
+    pkgs.git
+
     # Kubernetes
     pkgs.kind
     pkgs.kubectl


### PR DESCRIPTION
## 変更内容
- `devenv.nix`に`pkgs.git`を追加
  - `direnv allow`が成功することを確認