### PR TITLE
fix: use --authfile for skopeo to avoid /run/containers permission de…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,12 +211,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "$GITHUB_TOKEN" | skopeo login ghcr.io -u ${{ github.actor }} --password-stdin
+          AUTH_FILE="$(mktemp)"
+          echo "$GITHUB_TOKEN" | skopeo login ghcr.io -u ${{ github.actor }} --password-stdin --authfile "$AUTH_FILE"
           for svc in caller greeter gateway; do
             nix build .#${svc}-image
-            bash ./result | skopeo copy docker-archive:/dev/stdin \
+            bash ./result | skopeo copy --authfile "$AUTH_FILE" docker-archive:/dev/stdin \
               docker://ghcr.io/hackz-megalo-cup/${svc}:${{ github.sha }}
-            skopeo copy \
+            skopeo copy --authfile "$AUTH_FILE" \
               docker://ghcr.io/hackz-megalo-cup/${svc}:${{ github.sha }} \
               docker://ghcr.io/hackz-megalo-cup/${svc}:latest
           done


### PR DESCRIPTION
skopeo login defaults to /run/containers/<uid>/auth.json which is not writable on GitHub Actions runners. Use a temporary file instead.