### PR TITLE
fix(ci): initialize skopeo authfile and add Cachix substituter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           AUTH_FILE="$(mktemp)"
+          echo '{}' > "$AUTH_FILE"
           echo "$GITHUB_TOKEN" | skopeo login ghcr.io -u ${{ github.actor }} --password-stdin --authfile "$AUTH_FILE"
           for svc in caller greeter gateway; do
             nix build .#${svc}-image

--- a/flake.nix
+++ b/flake.nix
@@ -23,8 +23,8 @@
   };
 
   nixConfig = {
-    extra-trusted-public-keys = "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=";
-    extra-substituters = "https://devenv.cachix.org";
+    extra-trusted-public-keys = "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= hackz-megalo-cup.cachix.org-1:21679nTC27hKWUad5U5+MGAxkw1+8y0/9RGAbuvlmUY=";
+    extra-substituters = "https://devenv.cachix.org https://hackz-megalo-cup.cachix.org";
   };
 
   outputs =


### PR DESCRIPTION
Initialize authfile with empty JSON before skopeo login to prevent parse errors. Add hackz-megalo-cup Cachix binary cache for faster Nix builds.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hackz-megalo-cup/microservices-app/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
