### PR TITLE
fix(ci): use nix run copyToRegistry instead of ./result/copyTo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,8 +171,7 @@ jobs:
         run: |
           echo "$GITHUB_TOKEN" | skopeo login ghcr.io -u ${{ github.actor }} --password-stdin
           for svc in caller greeter gateway; do
-            nix build .#${svc}-image
-            ./result/copyTo docker://ghcr.io/hackz-megalo-cup/${svc}:${{ github.sha }}
+            nix run .#${svc}-image.copyToRegistry -- docker://ghcr.io/hackz-megalo-cup/${svc}:${{ github.sha }}
             if [ "$GITHUB_REF" = "refs/heads/main" ]; then
               skopeo copy \
                 docker://ghcr.io/hackz-megalo-cup/${svc}:${{ github.sha }} \


### PR DESCRIPTION
nix2container buildImage outputs image.json, not a directory with copyTo script. copyToRegistry is a passthru attribute accessible only via nix run.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hackz-megalo-cup/microservices-app/pull/83" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
