### PR TITLE
fix: create tmp dir for frontend nginx

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -259,7 +259,7 @@
               pkgs.nginx
             ];
             text = ''
-              mkdir -p /etc /var/log/nginx
+              mkdir -p /etc /tmp /var/log/nginx
               cat > /etc/passwd <<'EOF'
               root:x:0:0:root:/root:/sbin/nologin
               nobody:x:65534:65534:nobody:/:/sbin/nologin


### PR DESCRIPTION
Adds /tmp creation to the frontend nginx runner so the SHA-pinned frontend image can start cleanly in EKS.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hackz-megalo-cup/microservices-app/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
