### PR TITLE
fix: update goVendorHash for new dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -95,7 +95,7 @@
           # Microservices (connect-go) — go.mod requires go 1.26
           buildGoModule = pkgs.buildGo126Module;
           goServiceVersion = "0.1.0";
-          goVendorHash = "sha256-fzgNa+0Y5biTxqcK6VelnCzzIElzxeiLb653GhKKR7E=";
+          goVendorHash = "sha256-9mDtmS5axcsP/YiqrIcZT6YkysC0OegilaNfWNPvp80=";
           servicesRoot = toString ./services;
           goServiceInputs = {
             caller = {


### PR DESCRIPTION
## Summary
- Update `goVendorHash` in `flake.nix` to match current `vendor/` contents
- Fixes nix-build CI failure caused by new dependencies (`go-sqlmock`, `golang-jwt`)

## Test plan
- [ ] nix-build CI job passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hackz-megalo-cup/microservices-app/pull/109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
