### PR TITLE
fix: go mod tidy and remove duplicate topic constants

### DIFF
--- a/services/go.mod
+++ b/services/go.mod
@@ -6,7 +6,6 @@ require (
 	agones.dev/agones v1.56.0
 	connectrpc.com/connect v1.19.1
 	connectrpc.com/otelconnect v0.9.0
-	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/ThreeDotsLabs/watermill v1.5.1
 	github.com/ThreeDotsLabs/watermill-kafka/v3 v3.1.2
 	github.com/cenkalti/backoff/v5 v5.0.3
@@ -136,7 +135,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.7.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/oauth2 v0.32.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/term v0.40.0 // indirect

--- a/services/go.sum
+++ b/services/go.sum
@@ -52,8 +52,6 @@ github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg6
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
-github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/IBM/sarama v1.43.3 h1:Yj6L2IaNvb2mRBop39N7mmJAHBVY3dTPncr3qGVkxPA=
 github.com/IBM/sarama v1.43.3/go.mod h1:FVIRaLrhK3Cla/9FfRF5X9Zua2KpS3SYIXxhac1H+FQ=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
@@ -331,7 +329,6 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.18.4 h1:RPhnKRAQ4Fh8zU2FY/6ZFDwTVTxgJ/EMydqSTzE9a2c=
 github.com/klauspost/compress v1.18.4/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/services/internal/platform/topics.go
+++ b/services/internal/platform/topics.go
@@ -12,7 +12,6 @@ const (
 	TopicInvocationCreated = "invocation.created"
 	TopicUserRegistered    = "user.registered"
 	TopicUserLoggedIn      = "user.logged_in"
-	TopicCaptureCompleted  = "capture.completed"
 
 	// Saga compensation topics.
 	TopicGreetingFailed        = "greeting.failed"
@@ -58,7 +57,6 @@ const (
 	TopicUserLoggedInDLQ          = "user.logged_in.dlq"
 	TopicUserFailedDLQ            = "user.failed.dlq"
 	TopicUserCompensatedDLQ       = "user.compensated.dlq"
-	TopicCaptureCompletedDLQ      = "capture.completed.dlq"
 	TopicInvocationCompensatedDLQ = "invocation.compensated.dlq"
 	TopicItemCreatedDLQ           = "item.created.dlq"
 	TopicMasterdataCreatedDLQ     = "masterdata.created.dlq"
@@ -88,7 +86,6 @@ func DLQTopic(source string) string {
 		TopicRaidUserJoined:        TopicRaidUserJoinedDLQ,
 		TopicRaidBattleStarted:     TopicRaidBattleStartedDLQ,
 		TopicCaptureStarted:        TopicCaptureStartedDLQ,
-		TopicCaptureCompleted:      TopicCaptureCompletedDLQ,
 	}
 	return m[source]
 }
@@ -142,11 +139,9 @@ func DefaultTopics() map[string]int32 {
 		TopicCaptureStarted:           3,
 		TopicCaptureItemUsed:          3,
 		TopicCaptureBallThrown:        3,
-		TopicCaptureCompleted:         3,
 		TopicCaptureFailed:            1,
 		TopicCaptureCompensated:       1,
 		TopicCaptureStartedDLQ:        1,
-		TopicCaptureCompletedDLQ:      1,
 	}
 }
 


### PR DESCRIPTION
## Summary
- `go mod tidy` で未使用の依存 (`go-sqlmock`, `x/crypto`) を削除
- `topics.go` の `TopicCaptureCompleted` / `TopicCaptureCompletedDLQ` の重複 const 宣言を削除
- nix-build の `go: updates to go.mod needed` と `duplicate key` エラーを修正

## Test plan
- [x] `go build ./...` pass
- [x] `nix build .#go-services` pass locally
- [ ] CI nix-build job passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hackz-megalo-cup/microservices-app/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
