### PR TITLE
fix: migrate auth-service from Node to Go in nix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,9 +115,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          go_services=(caller gateway greeter item masterdata projector raid-lobby capture)
+          go_services=(auth caller gateway greeter item masterdata projector raid-lobby capture)
           release_images=(
-            .#auth-service-image
+            .#auth-image
             .#custom-lang-service-image
             .#frontend-image
             .#caller-image
@@ -199,7 +199,7 @@ jobs:
           done
 
           if [[ "$NIX_CHANGED" == "true" || "$NODE_CHANGED" == "true" ]]; then
-            add_pr_image .#auth-service-image
+            add_pr_image .#auth-image
             add_pr_image .#custom-lang-service-image
           fi
           if [[ "$NIX_CHANGED" == "true" || "$FRONTEND_CHANGED" == "true" ]]; then
@@ -208,7 +208,7 @@ jobs:
 
           image_attrs=()
           pr_image_order=(
-            .#auth-service-image
+            .#auth-image
             .#custom-lang-service-image
             .#frontend-image
             .#caller-image

--- a/flake.nix
+++ b/flake.nix
@@ -98,6 +98,10 @@
           goVendorHash = "sha256-9mDtmS5axcsP/YiqrIcZT6YkysC0OegilaNfWNPvp80=";
           servicesRoot = toString ./services;
           goServiceInputs = {
+            auth = {
+              internals = [ "auth" ];
+              gen = [ "auth" ];
+            };
             caller = {
               internals = [ "caller" ];
               gen = [ "caller" ];
@@ -205,6 +209,7 @@
             name = "go-services";
             src = ./services;
             subPackages = [
+              "cmd/auth"
               "cmd/caller"
               "cmd/gateway"
               "cmd/greeter"
@@ -228,6 +233,10 @@
                 (nix2containerPkgs.nix2container.buildLayer { deps = [ package ]; })
               ];
             };
+
+          auth = buildGoService "auth";
+          auth-image = buildGoServiceImage "auth" auth;
+          auth-release-image = buildGoServiceImage "auth" go-services;
 
           caller = buildGoService "caller";
           caller-image = buildGoServiceImage "caller" caller;
@@ -312,9 +321,6 @@
                 })
               ];
             };
-
-          auth-service = buildNodeService "auth-service" (nodeServiceNodeModules "auth-service");
-          auth-service-image = buildNodeServiceImage "auth-service" auth-service;
 
           custom-lang-service = buildNodeService "custom-lang-service" (
             nodeServiceNodeModules "custom-lang-service"
@@ -440,8 +446,9 @@
           packages.caller = caller;
           packages.caller-image = caller-image;
           packages.caller-release-image = caller-release-image;
-          packages.auth-service = auth-service;
-          packages.auth-service-image = auth-service-image;
+          packages.auth = auth;
+          packages.auth-image = auth-image;
+          packages.auth-release-image = auth-release-image;
           packages.custom-lang-service = custom-lang-service;
           packages.custom-lang-service-image = custom-lang-service-image;
           packages.frontend = frontend-assets;


### PR DESCRIPTION
## Summary
- `flake.nix`: Node版 `auth-service` 削除 → Go版 `auth` を goServiceInputs / go-services / packages に追加
- `ci.yml`: `auth-service-image` → `auth-image`、go_services リストに `auth` 追加

## Test plan
- [ ] nix-build CI passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hackz-megalo-cup/microservices-app/pull/111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
