### PR TITLE
fix: update goVendorHash and capture vendorHash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -95,7 +95,7 @@
           # Microservices (connect-go) — go.mod requires go 1.26
           buildGoModule = pkgs.buildGo126Module;
           goServiceVersion = "0.1.0";
-          goVendorHash = "sha256-9mDtmS5axcsP/YiqrIcZT6YkysC0OegilaNfWNPvp80=";
+          goVendorHash = "sha256-MMHm0r37BNzgmkrZUb+OCbbcptqpBJEoK1hSgBM+ceY=";
           servicesRoot = toString ./services;
           goServiceInputs = {
             auth = {
@@ -146,7 +146,7 @@
                 "item"
                 "masterdata"
               ];
-              vendorHash = "sha256-0kjB3UTON7eZJEZ9vIZlN3RqGLryhklu8fcMLowv53A=";
+              vendorHash = "sha256-DW+NKaC3W4XXy1/tGCOgwbwqnwiwVwcZvtffZ7dPrcU=";
             };
           };
           goServiceSource =


### PR DESCRIPTION
## Summary
- Update `goVendorHash` for all Go services
- Update capture-specific `vendorHash`
- Fixes nix-build CI failure after go mod tidy

## Test plan
- [x] `nix build .#go-services` passes locally
- [x] `nix build .#capture` passes locally
- [ ] CI nix-build passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hackz-megalo-cup/microservices-app/pull/114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
