### PR TITLE
fix: split vendorHash for individual services and go-services

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -95,7 +95,7 @@
           # Microservices (connect-go) — go.mod requires go 1.26
           buildGoModule = pkgs.buildGo126Module;
           goServiceVersion = "0.1.0";
-          goVendorHash = "sha256-MMHm0r37BNzgmkrZUb+OCbbcptqpBJEoK1hSgBM+ceY=";
+          goVendorHash = "sha256-DW+NKaC3W4XXy1/tGCOgwbwqnwiwVwcZvtffZ7dPrcU=";
           servicesRoot = toString ./services;
           goServiceInputs = {
             auth = {
@@ -146,7 +146,6 @@
                 "item"
                 "masterdata"
               ];
-              vendorHash = "sha256-DW+NKaC3W4XXy1/tGCOgwbwqnwiwVwcZvtffZ7dPrcU=";
             };
           };
           goServiceSource =
@@ -219,6 +218,7 @@
               "cmd/raid-lobby"
               "cmd/capture"
             ];
+            vendorHash = "sha256-MMHm0r37BNzgmkrZUb+OCbbcptqpBJEoK1hSgBM+ceY=";
           };
 
           buildGoServiceImage =


### PR DESCRIPTION
## Summary
- `goVendorHash` → 個別サービス用 (source-filtered)
- `go-services` に専用 `vendorHash` を追加 (full source)
- capture の冗長な vendorHash override を削除

## Test plan
- [x] `nix build .#caller` passes locally
- [x] `nix build .#go-services` passes locally
- [x] `nix build .#capture` passes locally
- [ ] CI nix-build passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hackz-megalo-cup/microservices-app/pull/115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
