### PR TITLE
fix: share goModules across all Go service builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -95,7 +95,7 @@
           # Microservices (connect-go) — go.mod requires go 1.26
           buildGoModule = pkgs.buildGo126Module;
           goServiceVersion = "0.1.0";
-          goVendorHash = "sha256-DW+NKaC3W4XXy1/tGCOgwbwqnwiwVwcZvtffZ7dPrcU=";
+          goVendorHash = "sha256-MMHm0r37BNzgmkrZUb+OCbbcptqpBJEoK1hSgBM+ceY=";
           servicesRoot = toString ./services;
           goServiceInputs = {
             auth = {
@@ -175,38 +175,12 @@
                   || lib.any (prefix: matchesTree relPath "gen/go/${prefix}") cfg.gen
                 );
             };
-          buildGoPackage =
-            {
-              name,
-              src,
-              subPackages,
-              vendorHash ? goVendorHash,
-            }:
-            buildGoModule {
-              pname = name;
-              version = goServiceVersion;
-              inherit src subPackages vendorHash;
-              doCheck = false;
-              env.CGO_ENABLED = 0;
-              ldflags = [
-                "-s"
-                "-w"
-              ];
-            };
-          buildGoService =
-            name:
-            let
-              cfg = goServiceInputs.${name};
-            in
-            buildGoPackage {
-              inherit name;
-              src = goServiceSource name;
-              subPackages = [ "cmd/${name}" ];
-              vendorHash = cfg.vendorHash or goVendorHash;
-            };
-          go-services = buildGoPackage {
-            name = "go-services";
+          # Build go-services with full source — its goModules is reused by per-service builds.
+          go-services = buildGoModule {
+            pname = "go-services";
+            version = goServiceVersion;
             src = ./services;
+            vendorHash = goVendorHash;
             subPackages = [
               "cmd/auth"
               "cmd/caller"
@@ -218,8 +192,33 @@
               "cmd/raid-lobby"
               "cmd/capture"
             ];
-            vendorHash = "sha256-MMHm0r37BNzgmkrZUb+OCbbcptqpBJEoK1hSgBM+ceY=";
+            doCheck = false;
+            env.CGO_ENABLED = 0;
+            ldflags = [
+              "-s"
+              "-w"
+            ];
           };
+          # Per-service builds: vendorHash = null + copy vendor from go-services.goModules.
+          # Only ONE vendorHash (goVendorHash) needs to be maintained.
+          buildGoService =
+            name:
+            buildGoModule {
+              pname = name;
+              version = goServiceVersion;
+              src = goServiceSource name;
+              vendorHash = null;
+              subPackages = [ "cmd/${name}" ];
+              doCheck = false;
+              env.CGO_ENABLED = 0;
+              ldflags = [
+                "-s"
+                "-w"
+              ];
+              preBuild = ''
+                cp -r --reflink=auto ${go-services.goModules} vendor
+              '';
+            };
 
           buildGoServiceImage =
             name: package:


### PR DESCRIPTION
## Summary

### 問題
`buildGoModule` の `vendorHash` は `go mod vendor` の出力ハッシュ。
ソースフィルタで各サービスが別々のソースを使うと、`go mod vendor` の出力が変わり、vendorHash がサービスごとに異なる値になる。
依存を変更するたびに複数の hash を更新する必要があり、CI が壊れ続けていた。

### 解決策
- `go-services`（全ソース）で goModules を1回だけビルド
- 個別サービスは `vendorHash = null` + `preBuild` で `go-services.goModules` の vendor をコピー
- 管理する vendorHash は **1つだけ** (`goVendorHash`)

### ローカルで全サービスビルド確認済み
```
nix build .#auth .#caller .#capture .#gateway .#greeter .#item .#masterdata .#projector .#raid-lobby .#go-services
```

## Test plan
- [x] All 9 individual services build locally
- [x] go-services builds locally
- [ ] CI nix-build passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hackz-megalo-cup/microservices-app/pull/116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
