### PR TITLE
fix(item): implement GetUserItems RPC to retrieve user's items

### DIFF
--- a/frontend/src/gen/item/v1/item-ItemService_connectquery.ts
+++ b/frontend/src/gen/item/v1/item-ItemService_connectquery.ts
@@ -13,3 +13,8 @@ export const grantItem = ItemService.method.grantItem;
  * @generated from rpc item.v1.ItemService.UseItem
  */
 export const useItem = ItemService.method.useItem;
+
+/**
+ * @generated from rpc item.v1.ItemService.GetUserItems
+ */
+export const getUserItems = ItemService.method.getUserItems;

--- a/frontend/src/gen/item/v1/item_pb.ts
+++ b/frontend/src/gen/item/v1/item_pb.ts
@@ -10,7 +10,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file item/v1/item.proto.
  */
 export const file_item_v1_item: GenFile = /*@__PURE__*/
-  fileDesc("ChJpdGVtL3YxL2l0ZW0ucHJvdG8SB2l0ZW0udjEiVgoQR3JhbnRJdGVtUmVxdWVzdBIPCgd1c2VyX2lkGAEgASgJEg8KB2l0ZW1faWQYAiABKAkSEAoIcXVhbnRpdHkYAyABKAUSDgoGcmVhc29uGAQgASgJIh8KEUdyYW50SXRlbVJlc3BvbnNlEgoKAmlkGAEgASgJIkQKDlVzZUl0ZW1SZXF1ZXN0Eg8KB3VzZXJfaWQYASABKAkSDwoHaXRlbV9pZBgCIAEoCRIQCghxdWFudGl0eRgDIAEoBSIRCg9Vc2VJdGVtUmVzcG9uc2UykwEKC0l0ZW1TZXJ2aWNlEkQKCUdyYW50SXRlbRIZLml0ZW0udjEuR3JhbnRJdGVtUmVxdWVzdBoaLml0ZW0udjEuR3JhbnRJdGVtUmVzcG9uc2UiABI+CgdVc2VJdGVtEhcuaXRlbS52MS5Vc2VJdGVtUmVxdWVzdBoYLml0ZW0udjEuVXNlSXRlbVJlc3BvbnNlIgBCTlpMZ2l0aHViLmNvbS9oYWNrei1tZWdhbG8tY3VwL21pY3Jvc2VydmljZXMtYXBwL3NlcnZpY2VzL2dlbi9nby9pdGVtL3YxO2l0ZW12MWIGcHJvdG8z");
+  fileDesc("ChJpdGVtL3YxL2l0ZW0ucHJvdG8SB2l0ZW0udjEiVgoQR3JhbnRJdGVtUmVxdWVzdBIPCgd1c2VyX2lkGAEgASgJEg8KB2l0ZW1faWQYAiABKAkSEAoIcXVhbnRpdHkYAyABKAUSDgoGcmVhc29uGAQgASgJIh8KEUdyYW50SXRlbVJlc3BvbnNlEgoKAmlkGAEgASgJIkQKDlVzZUl0ZW1SZXF1ZXN0Eg8KB3VzZXJfaWQYASABKAkSDwoHaXRlbV9pZBgCIAEoCRIQCghxdWFudGl0eRgDIAEoBSIRCg9Vc2VJdGVtUmVzcG9uc2UiJgoTR2V0VXNlckl0ZW1zUmVxdWVzdBIPCgd1c2VyX2lkGAEgASgJIj0KCFVzZXJJdGVtEg8KB2l0ZW1faWQYASABKAkSEAoIcXVhbnRpdHkYAiABKAUSDgoGc3RhdHVzGAMgASgJIjgKFEdldFVzZXJJdGVtc1Jlc3BvbnNlEiAKBWl0ZW1zGAEgAygLMhEuaXRlbS52MS5Vc2VySXRlbTLiAQoLSXRlbVNlcnZpY2USRAoJR3JhbnRJdGVtEhkuaXRlbS52MS5HcmFudEl0ZW1SZXF1ZXN0GhouaXRlbS52MS5HcmFudEl0ZW1SZXNwb25zZSIAEj4KB1VzZUl0ZW0SFy5pdGVtLnYxLlVzZUl0ZW1SZXF1ZXN0GhguaXRlbS52MS5Vc2VJdGVtUmVzcG9uc2UiABJNCgxHZXRVc2VySXRlbXMSHC5pdGVtLnYxLkdldFVzZXJJdGVtc1JlcXVlc3QaHS5pdGVtLnYxLkdldFVzZXJJdGVtc1Jlc3BvbnNlIgBCTlpMZ2l0aHViLmNvbS9oYWNrei1tZWdhbG8tY3VwL21pY3Jvc2VydmljZXMtYXBwL3NlcnZpY2VzL2dlbi9nby9pdGVtL3YxO2l0ZW12MWIGcHJvdG8z");
 
 /**
  * @generated from message item.v1.GrantItemRequest
@@ -102,6 +102,67 @@ export const UseItemResponseSchema: GenMessage<UseItemResponse> = /*@__PURE__*/
   messageDesc(file_item_v1_item, 3);
 
 /**
+ * @generated from message item.v1.GetUserItemsRequest
+ */
+export type GetUserItemsRequest = Message<"item.v1.GetUserItemsRequest"> & {
+  /**
+   * @generated from field: string user_id = 1;
+   */
+  userId: string;
+};
+
+/**
+ * Describes the message item.v1.GetUserItemsRequest.
+ * Use `create(GetUserItemsRequestSchema)` to create a new message.
+ */
+export const GetUserItemsRequestSchema: GenMessage<GetUserItemsRequest> = /*@__PURE__*/
+  messageDesc(file_item_v1_item, 4);
+
+/**
+ * @generated from message item.v1.UserItem
+ */
+export type UserItem = Message<"item.v1.UserItem"> & {
+  /**
+   * @generated from field: string item_id = 1;
+   */
+  itemId: string;
+
+  /**
+   * @generated from field: int32 quantity = 2;
+   */
+  quantity: number;
+
+  /**
+   * @generated from field: string status = 3;
+   */
+  status: string;
+};
+
+/**
+ * Describes the message item.v1.UserItem.
+ * Use `create(UserItemSchema)` to create a new message.
+ */
+export const UserItemSchema: GenMessage<UserItem> = /*@__PURE__*/
+  messageDesc(file_item_v1_item, 5);
+
+/**
+ * @generated from message item.v1.GetUserItemsResponse
+ */
+export type GetUserItemsResponse = Message<"item.v1.GetUserItemsResponse"> & {
+  /**
+   * @generated from field: repeated item.v1.UserItem items = 1;
+   */
+  items: UserItem[];
+};
+
+/**
+ * Describes the message item.v1.GetUserItemsResponse.
+ * Use `create(GetUserItemsResponseSchema)` to create a new message.
+ */
+export const GetUserItemsResponseSchema: GenMessage<GetUserItemsResponse> = /*@__PURE__*/
+  messageDesc(file_item_v1_item, 6);
+
+/**
  * @generated from service item.v1.ItemService
  */
 export const ItemService: GenService<{
@@ -120,6 +181,14 @@ export const ItemService: GenService<{
     methodKind: "unary";
     input: typeof UseItemRequestSchema;
     output: typeof UseItemResponseSchema;
+  },
+  /**
+   * @generated from rpc item.v1.ItemService.GetUserItems
+   */
+  getUserItems: {
+    methodKind: "unary";
+    input: typeof GetUserItemsRequestSchema;
+    output: typeof GetUserItemsResponseSchema;
   },
 }> = /*@__PURE__*/
   serviceDesc(file_item_v1_item, 0);

--- a/proto/item/v1/item.proto
+++ b/proto/item/v1/item.proto
@@ -7,6 +7,7 @@ option go_package = "github.com/hackz-megalo-cup/microservices-app/services/gen/
 service ItemService {
   rpc GrantItem(GrantItemRequest) returns (GrantItemResponse) {}
   rpc UseItem(UseItemRequest) returns (UseItemResponse) {}
+  rpc GetUserItems(GetUserItemsRequest) returns (GetUserItemsResponse) {}
 }
 
 message GrantItemRequest {
@@ -27,3 +28,17 @@ message UseItemRequest {
 }
 
 message UseItemResponse {}
+
+message GetUserItemsRequest {
+  string user_id = 1;
+}
+
+message UserItem {
+  string item_id = 1;
+  int32 quantity = 2;
+  string status = 3;
+}
+
+message GetUserItemsResponse {
+  repeated UserItem items = 1;
+}

--- a/services/cmd/item/main.go
+++ b/services/cmd/item/main.go
@@ -108,7 +108,7 @@ func run() error {
 	platform.StartIdempotencyCleanup(ctx, idempotencyStore)
 
 	// --- Service ---
-	svc := item.NewService(eventStore, outbox)
+	svc := item.NewService(eventStore, outbox, dbPool)
 
 	// --- Connect-RPC Handler with interceptors ---
 	otelInterceptor, err := otelconnect.NewInterceptor(otelconnect.WithTrustRemote())

--- a/services/gen/go/item/v1/item.pb.go
+++ b/services/gen/go/item/v1/item.pb.go
@@ -229,6 +229,154 @@ func (*UseItemResponse) Descriptor() ([]byte, []int) {
 	return file_item_v1_item_proto_rawDescGZIP(), []int{3}
 }
 
+type GetUserItemsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetUserItemsRequest) Reset() {
+	*x = GetUserItemsRequest{}
+	mi := &file_item_v1_item_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetUserItemsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetUserItemsRequest) ProtoMessage() {}
+
+func (x *GetUserItemsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_item_v1_item_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetUserItemsRequest.ProtoReflect.Descriptor instead.
+func (*GetUserItemsRequest) Descriptor() ([]byte, []int) {
+	return file_item_v1_item_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *GetUserItemsRequest) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+type UserItem struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ItemId        string                 `protobuf:"bytes,1,opt,name=item_id,json=itemId,proto3" json:"item_id,omitempty"`
+	Quantity      int32                  `protobuf:"varint,2,opt,name=quantity,proto3" json:"quantity,omitempty"`
+	Status        string                 `protobuf:"bytes,3,opt,name=status,proto3" json:"status,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UserItem) Reset() {
+	*x = UserItem{}
+	mi := &file_item_v1_item_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserItem) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserItem) ProtoMessage() {}
+
+func (x *UserItem) ProtoReflect() protoreflect.Message {
+	mi := &file_item_v1_item_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UserItem.ProtoReflect.Descriptor instead.
+func (*UserItem) Descriptor() ([]byte, []int) {
+	return file_item_v1_item_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *UserItem) GetItemId() string {
+	if x != nil {
+		return x.ItemId
+	}
+	return ""
+}
+
+func (x *UserItem) GetQuantity() int32 {
+	if x != nil {
+		return x.Quantity
+	}
+	return 0
+}
+
+func (x *UserItem) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+type GetUserItemsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Items         []*UserItem            `protobuf:"bytes,1,rep,name=items,proto3" json:"items,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetUserItemsResponse) Reset() {
+	*x = GetUserItemsResponse{}
+	mi := &file_item_v1_item_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetUserItemsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetUserItemsResponse) ProtoMessage() {}
+
+func (x *GetUserItemsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_item_v1_item_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetUserItemsResponse.ProtoReflect.Descriptor instead.
+func (*GetUserItemsResponse) Descriptor() ([]byte, []int) {
+	return file_item_v1_item_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *GetUserItemsResponse) GetItems() []*UserItem {
+	if x != nil {
+		return x.Items
+	}
+	return nil
+}
+
 var File_item_v1_item_proto protoreflect.FileDescriptor
 
 const file_item_v1_item_proto_rawDesc = "" +
@@ -245,10 +393,19 @@ const file_item_v1_item_proto_rawDesc = "" +
 	"\auser_id\x18\x01 \x01(\tR\x06userId\x12\x17\n" +
 	"\aitem_id\x18\x02 \x01(\tR\x06itemId\x12\x1a\n" +
 	"\bquantity\x18\x03 \x01(\x05R\bquantity\"\x11\n" +
-	"\x0fUseItemResponse2\x93\x01\n" +
+	"\x0fUseItemResponse\".\n" +
+	"\x13GetUserItemsRequest\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\"W\n" +
+	"\bUserItem\x12\x17\n" +
+	"\aitem_id\x18\x01 \x01(\tR\x06itemId\x12\x1a\n" +
+	"\bquantity\x18\x02 \x01(\x05R\bquantity\x12\x16\n" +
+	"\x06status\x18\x03 \x01(\tR\x06status\"?\n" +
+	"\x14GetUserItemsResponse\x12'\n" +
+	"\x05items\x18\x01 \x03(\v2\x11.item.v1.UserItemR\x05items2\xe2\x01\n" +
 	"\vItemService\x12D\n" +
 	"\tGrantItem\x12\x19.item.v1.GrantItemRequest\x1a\x1a.item.v1.GrantItemResponse\"\x00\x12>\n" +
-	"\aUseItem\x12\x17.item.v1.UseItemRequest\x1a\x18.item.v1.UseItemResponse\"\x00BNZLgithub.com/hackz-megalo-cup/microservices-app/services/gen/go/item/v1;itemv1b\x06proto3"
+	"\aUseItem\x12\x17.item.v1.UseItemRequest\x1a\x18.item.v1.UseItemResponse\"\x00\x12M\n" +
+	"\fGetUserItems\x12\x1c.item.v1.GetUserItemsRequest\x1a\x1d.item.v1.GetUserItemsResponse\"\x00BNZLgithub.com/hackz-megalo-cup/microservices-app/services/gen/go/item/v1;itemv1b\x06proto3"
 
 var (
 	file_item_v1_item_proto_rawDescOnce sync.Once
@@ -262,23 +419,29 @@ func file_item_v1_item_proto_rawDescGZIP() []byte {
 	return file_item_v1_item_proto_rawDescData
 }
 
-var file_item_v1_item_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_item_v1_item_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_item_v1_item_proto_goTypes = []any{
-	(*GrantItemRequest)(nil),  // 0: item.v1.GrantItemRequest
-	(*GrantItemResponse)(nil), // 1: item.v1.GrantItemResponse
-	(*UseItemRequest)(nil),    // 2: item.v1.UseItemRequest
-	(*UseItemResponse)(nil),   // 3: item.v1.UseItemResponse
+	(*GrantItemRequest)(nil),     // 0: item.v1.GrantItemRequest
+	(*GrantItemResponse)(nil),    // 1: item.v1.GrantItemResponse
+	(*UseItemRequest)(nil),       // 2: item.v1.UseItemRequest
+	(*UseItemResponse)(nil),      // 3: item.v1.UseItemResponse
+	(*GetUserItemsRequest)(nil),  // 4: item.v1.GetUserItemsRequest
+	(*UserItem)(nil),             // 5: item.v1.UserItem
+	(*GetUserItemsResponse)(nil), // 6: item.v1.GetUserItemsResponse
 }
 var file_item_v1_item_proto_depIdxs = []int32{
-	0, // 0: item.v1.ItemService.GrantItem:input_type -> item.v1.GrantItemRequest
-	2, // 1: item.v1.ItemService.UseItem:input_type -> item.v1.UseItemRequest
-	1, // 2: item.v1.ItemService.GrantItem:output_type -> item.v1.GrantItemResponse
-	3, // 3: item.v1.ItemService.UseItem:output_type -> item.v1.UseItemResponse
-	2, // [2:4] is the sub-list for method output_type
-	0, // [0:2] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	5, // 0: item.v1.GetUserItemsResponse.items:type_name -> item.v1.UserItem
+	0, // 1: item.v1.ItemService.GrantItem:input_type -> item.v1.GrantItemRequest
+	2, // 2: item.v1.ItemService.UseItem:input_type -> item.v1.UseItemRequest
+	4, // 3: item.v1.ItemService.GetUserItems:input_type -> item.v1.GetUserItemsRequest
+	1, // 4: item.v1.ItemService.GrantItem:output_type -> item.v1.GrantItemResponse
+	3, // 5: item.v1.ItemService.UseItem:output_type -> item.v1.UseItemResponse
+	6, // 6: item.v1.ItemService.GetUserItems:output_type -> item.v1.GetUserItemsResponse
+	4, // [4:7] is the sub-list for method output_type
+	1, // [1:4] is the sub-list for method input_type
+	1, // [1:1] is the sub-list for extension type_name
+	1, // [1:1] is the sub-list for extension extendee
+	0, // [0:1] is the sub-list for field type_name
 }
 
 func init() { file_item_v1_item_proto_init() }
@@ -292,7 +455,7 @@ func file_item_v1_item_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_item_v1_item_proto_rawDesc), len(file_item_v1_item_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/services/gen/go/item/v1/itemv1connect/item.connect.go
+++ b/services/gen/go/item/v1/itemv1connect/item.connect.go
@@ -37,12 +37,16 @@ const (
 	ItemServiceGrantItemProcedure = "/item.v1.ItemService/GrantItem"
 	// ItemServiceUseItemProcedure is the fully-qualified name of the ItemService's UseItem RPC.
 	ItemServiceUseItemProcedure = "/item.v1.ItemService/UseItem"
+	// ItemServiceGetUserItemsProcedure is the fully-qualified name of the ItemService's GetUserItems
+	// RPC.
+	ItemServiceGetUserItemsProcedure = "/item.v1.ItemService/GetUserItems"
 )
 
 // ItemServiceClient is a client for the item.v1.ItemService service.
 type ItemServiceClient interface {
 	GrantItem(context.Context, *connect.Request[v1.GrantItemRequest]) (*connect.Response[v1.GrantItemResponse], error)
 	UseItem(context.Context, *connect.Request[v1.UseItemRequest]) (*connect.Response[v1.UseItemResponse], error)
+	GetUserItems(context.Context, *connect.Request[v1.GetUserItemsRequest]) (*connect.Response[v1.GetUserItemsResponse], error)
 }
 
 // NewItemServiceClient constructs a client for the item.v1.ItemService service. By default, it uses
@@ -68,13 +72,20 @@ func NewItemServiceClient(httpClient connect.HTTPClient, baseURL string, opts ..
 			connect.WithSchema(itemServiceMethods.ByName("UseItem")),
 			connect.WithClientOptions(opts...),
 		),
+		getUserItems: connect.NewClient[v1.GetUserItemsRequest, v1.GetUserItemsResponse](
+			httpClient,
+			baseURL+ItemServiceGetUserItemsProcedure,
+			connect.WithSchema(itemServiceMethods.ByName("GetUserItems")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
 // itemServiceClient implements ItemServiceClient.
 type itemServiceClient struct {
-	grantItem *connect.Client[v1.GrantItemRequest, v1.GrantItemResponse]
-	useItem   *connect.Client[v1.UseItemRequest, v1.UseItemResponse]
+	grantItem    *connect.Client[v1.GrantItemRequest, v1.GrantItemResponse]
+	useItem      *connect.Client[v1.UseItemRequest, v1.UseItemResponse]
+	getUserItems *connect.Client[v1.GetUserItemsRequest, v1.GetUserItemsResponse]
 }
 
 // GrantItem calls item.v1.ItemService.GrantItem.
@@ -87,10 +98,16 @@ func (c *itemServiceClient) UseItem(ctx context.Context, req *connect.Request[v1
 	return c.useItem.CallUnary(ctx, req)
 }
 
+// GetUserItems calls item.v1.ItemService.GetUserItems.
+func (c *itemServiceClient) GetUserItems(ctx context.Context, req *connect.Request[v1.GetUserItemsRequest]) (*connect.Response[v1.GetUserItemsResponse], error) {
+	return c.getUserItems.CallUnary(ctx, req)
+}
+
 // ItemServiceHandler is an implementation of the item.v1.ItemService service.
 type ItemServiceHandler interface {
 	GrantItem(context.Context, *connect.Request[v1.GrantItemRequest]) (*connect.Response[v1.GrantItemResponse], error)
 	UseItem(context.Context, *connect.Request[v1.UseItemRequest]) (*connect.Response[v1.UseItemResponse], error)
+	GetUserItems(context.Context, *connect.Request[v1.GetUserItemsRequest]) (*connect.Response[v1.GetUserItemsResponse], error)
 }
 
 // NewItemServiceHandler builds an HTTP handler from the service implementation. It returns the path
@@ -112,12 +129,20 @@ func NewItemServiceHandler(svc ItemServiceHandler, opts ...connect.HandlerOption
 		connect.WithSchema(itemServiceMethods.ByName("UseItem")),
 		connect.WithHandlerOptions(opts...),
 	)
+	itemServiceGetUserItemsHandler := connect.NewUnaryHandler(
+		ItemServiceGetUserItemsProcedure,
+		svc.GetUserItems,
+		connect.WithSchema(itemServiceMethods.ByName("GetUserItems")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/item.v1.ItemService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case ItemServiceGrantItemProcedure:
 			itemServiceGrantItemHandler.ServeHTTP(w, r)
 		case ItemServiceUseItemProcedure:
 			itemServiceUseItemHandler.ServeHTTP(w, r)
+		case ItemServiceGetUserItemsProcedure:
+			itemServiceGetUserItemsHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -133,4 +158,8 @@ func (UnimplementedItemServiceHandler) GrantItem(context.Context, *connect.Reque
 
 func (UnimplementedItemServiceHandler) UseItem(context.Context, *connect.Request[v1.UseItemRequest]) (*connect.Response[v1.UseItemResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("item.v1.ItemService.UseItem is not implemented"))
+}
+
+func (UnimplementedItemServiceHandler) GetUserItems(context.Context, *connect.Request[v1.GetUserItemsRequest]) (*connect.Response[v1.GetUserItemsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("item.v1.ItemService.GetUserItems is not implemented"))
 }

--- a/services/internal/item/service.go
+++ b/services/internal/item/service.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 
 	"connectrpc.com/connect"
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	pb "github.com/hackz-megalo-cup/microservices-app/services/gen/go/item/v1"
 	"github.com/hackz-megalo-cup/microservices-app/services/internal/platform"
@@ -14,12 +15,14 @@ import (
 type Service struct {
 	eventStore *platform.EventStore
 	outbox     *platform.OutboxStore
+	dbPool     *pgxpool.Pool
 }
 
-func NewService(eventStore *platform.EventStore, outbox *platform.OutboxStore) *Service {
+func NewService(eventStore *platform.EventStore, outbox *platform.OutboxStore, dbPool *pgxpool.Pool) *Service {
 	return &Service{
 		eventStore: eventStore,
 		outbox:     outbox,
+		dbPool:     dbPool,
 	}
 }
 
@@ -92,4 +95,55 @@ func (s *Service) UseItem(ctx context.Context, req *connect.Request[pb.UseItemRe
 	}
 
 	return connect.NewResponse(&pb.UseItemResponse{}), nil
+}
+
+// GetUserItems — ユーザーが所持しているアイテムの一覧を取得する
+func (s *Service) GetUserItems(ctx context.Context, req *connect.Request[pb.GetUserItemsRequest]) (*connect.Response[pb.GetUserItemsResponse], error) {
+	userID := req.Msg.GetUserId()
+	if userID == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("user_id is required"))
+	}
+
+	// EventStore から user_id にマッチする全ストリームを取得
+	// stream_id パターン: "user_id:item_id"
+	rows, err := s.dbPool.Query(ctx, `
+		SELECT DISTINCT stream_id
+		FROM event_store
+		WHERE stream_type = 'item'
+		  AND stream_id LIKE $1 || ':%'
+		ORDER BY stream_id
+	`, userID)
+	if err != nil {
+		slog.Error("failed to query user items", "error", err)
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to query items"))
+	}
+	defer rows.Close()
+
+	var items []*pb.UserItem
+	for rows.Next() {
+		var streamID string
+		if err := rows.Scan(&streamID); err != nil {
+			continue
+		}
+
+		// 各集約をロードして現在の状態を取得
+		agg := NewItemAggregate(streamID)
+		if err := platform.LoadAggregate(ctx, s.eventStore, agg); err != nil {
+			slog.Warn("failed to load aggregate", "stream_id", streamID, "error", err)
+			continue
+		}
+
+		// quantity が 0 より大きいもののみ返す
+		if agg.Quantity > 0 {
+			items = append(items, &pb.UserItem{
+				ItemId:   agg.ItemID,
+				Quantity: agg.Quantity,
+				Status:   agg.Status,
+			})
+		}
+	}
+
+	return connect.NewResponse(&pb.GetUserItemsResponse{
+		Items: items,
+	}), nil
 }


### PR DESCRIPTION
Adds GetUserItems RPC to item service that returns all items owned by a user with quantity > 0. Implementation queries the event store for user-specific item streams and loads each aggregate to get current state.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hackz-megalo-cup/microservices-app/pull/125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
