### PR TITLE
fix: バトルタイマーの複数不具合を修正

### DIFF
--- a/frontend/src/features/battle/components/battle-page.tsx
+++ b/frontend/src/features/battle/components/battle-page.tsx
@@ -1,5 +1,5 @@
 import type { MouseEvent as ReactMouseEvent } from "react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import "../../../styles/global.css";
 import { useAuthContext } from "../../../lib/auth";
@@ -73,7 +73,7 @@ export function BattlePage() {
         case "joined":
           setBossHp(msg.bossHp);
           setBossMaxHp(msg.bossMaxHp);
-          if (msg.timeoutSec) {
+          if (msg.timeoutSec !== undefined) {
             setTimeoutSec(msg.timeoutSec);
           }
           if (msg.participants) {
@@ -112,6 +112,16 @@ export function BattlePage() {
     },
     [id, navigate, spawnDmg],
   );
+
+  useEffect(() => {
+    if (result !== null) {
+      return;
+    }
+    const timer = setInterval(() => {
+      setTimeoutSec((prev) => Math.max(0, prev - 1));
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [result]);
 
   const { status, sendTap, sendSpecial } = useGameConnection({
     userId,

--- a/game-server/internal/battle/session.go
+++ b/game-server/internal/battle/session.go
@@ -162,3 +162,13 @@ func (s *Session) ParticipantIDs() []uuid.UUID {
 func (s *Session) Done() <-chan struct{} {
 	return s.doneCh
 }
+
+func (s *Session) RemainingTime() time.Duration {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	remaining := s.TimeoutDuration - time.Since(s.StartedAt)
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}

--- a/game-server/internal/transport/handler.go
+++ b/game-server/internal/transport/handler.go
@@ -66,7 +66,7 @@ func (h *Handler) handleJoin(userID uuid.UUID) {
 		BossHP:       info.BossHP,
 		BossMaxHP:    info.BossMaxHP,
 		Participants: participants,
-		TimeoutSec:   int(info.TimeoutDuration / time.Second),
+		TimeoutSec:   int(h.session.RemainingTime() / time.Second),
 	}
 
 	data, err := MarshalJSON(joined)
@@ -163,11 +163,7 @@ func (h *Handler) StartTimeSync(ctx context.Context) {
 		case <-h.session.Done():
 			return
 		case <-ticker.C:
-			elapsed := time.Since(h.session.StartedAt)
-			remaining := h.session.TimeoutDuration - elapsed
-			if remaining < 0 {
-				remaining = 0
-			}
+			remaining := h.session.RemainingTime()
 
 			msg := TimeSyncMessage{
 				T:            "time_sync",


### PR DESCRIPTION
Fixes #147

## 変更内容

- 途中参加時の初期タイマー値を残り時間に修正
- Session.RemainingTime() メソッド追加でmutex付きアクセスに統一
- フロントエンドにローカルカウントダウン追加
- timeoutSec === 0 の falsy チェック漏れを修正

Generated with [Claude Code](https://claude.ai/code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hackz-megalo-cup/microservices-app/pull/148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
