### PR TITLE
feat(game-server): add local TLS setup for WebSocket connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ docs/plans/
 
 # Misc caches
 .cache/
+
+# mkcert local dev certs
+deploy/tls/

--- a/README.md
+++ b/README.md
@@ -151,6 +151,23 @@ docker compose up
 | http://localhost:8888 | Redpanda Console (Kafka UI) |
 | http://localhost:19092 | Redpanda Kafka (外部アクセス) |
 
+### 4. game-server の TLS セットアップ（初回のみ）
+
+game-server は WebSocket 接続にブラウザが信頼する TLS 証明書が必要。初回に一度だけセットアップスクリプトを実行する:
+
+```zsh
+./scripts/setup-tls.sh
+```
+
+これにより:
+- mkcert の CA がシステムにインストールされる（パスワードを聞かれる場合がある）
+- `deploy/tls/` に localhost 用証明書が生成される（docker compose 用、`.gitignore` 済み）
+- `/tmp/tls.{crt,key}` にもコピーされる（ローカル起動用）
+
+セットアップ後は `docker compose up --build -d` で game-server の WebSocket がブラウザから信頼される。
+
+> **Note**: mkcert がインストールされていない場合は `brew install mkcert` または devenv に入った状態で利用可能。
+
 ## フロントエンド開発
 
 ### 概要

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,6 +165,9 @@ services:
       LOCAL_DEV: "true"
       PORT: "7777"
       KAFKA_BROKERS: "redpanda:9092"
+      WS_CERT_PATH: "/etc/tls/mkcert"
+    volumes:
+      - ./deploy/tls:/etc/tls/mkcert:ro
     depends_on:
       redpanda:
         condition: service_healthy

--- a/scripts/setup-tls.sh
+++ b/scripts/setup-tls.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TLS_DIR="$REPO_ROOT/deploy/tls"
+
+echo "=== Local TLS Setup for game-server ==="
+
+# Check mkcert
+if ! command -v mkcert &>/dev/null; then
+  echo "ERROR: mkcert is not installed."
+  echo "  Install via: brew install mkcert  /  nix-env -i mkcert"
+  exit 1
+fi
+
+# Install CA if not already
+echo "==> Installing mkcert CA (may ask for password)..."
+mkcert -install
+
+# Generate certs
+mkdir -p "$TLS_DIR"
+
+if [ -f "$TLS_DIR/tls.crt" ] && [ -f "$TLS_DIR/tls.key" ]; then
+  echo "==> Certs already exist at $TLS_DIR, skipping generation."
+  echo "    Delete them and re-run to regenerate."
+else
+  echo "==> Generating localhost certs..."
+  mkcert -key-file "$TLS_DIR/tls.key" -cert-file "$TLS_DIR/tls.crt" localhost 127.0.0.1 ::1
+fi
+
+# Also copy to /tmp for local (non-docker) dev
+cp "$TLS_DIR/tls.crt" /tmp/tls.crt
+cp "$TLS_DIR/tls.key" /tmp/tls.key
+
+echo ""
+echo "=== Done! ==="
+echo "  Docker:  deploy/tls/ is mounted into game-server container"
+echo "  Local:   /tmp/tls.{crt,key} ready for WS_CERT_PATH=/tmp"
+echo ""
+echo "  Run: docker compose up --build -d"
+echo "  Or:  LOCAL_DEV=true WS_CERT_PATH=/tmp go run . (from game-server/)"


### PR DESCRIPTION
mkcert ベースの TLS 証明書セットアップスクリプトを追加し、
docker-compose で game-server に証明書をマウントする設定を追加
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hackz-megalo-cup/microservices-app/pull/156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
