### PR TITLE
feat: 手持ちポケモン切り替えUIを実装

### DIFF
--- a/frontend/src/features/showcase/components/collection.tsx
+++ b/frontend/src/features/showcase/components/collection.tsx
@@ -1,12 +1,16 @@
 import { useNavigate } from "react-router";
 import "../../../styles/global.css";
+import { useActivePokemon } from "../hooks/use-active-pokemon";
 import { useCollectionPokemon } from "../hooks/use-collection-pokemon";
+import { useSetActivePokemon } from "../hooks/use-set-active-pokemon";
 import { NavBar } from "./ui/nav-bar";
 import { TabBar } from "./ui/tab-bar";
 
 export function Collection() {
   const navigate = useNavigate();
   const { pokemon, isLoading, error, refetch } = useCollectionPokemon();
+  const { activeId } = useActivePokemon();
+  const setActiveMutation = useSetActivePokemon();
   const capturedCount = pokemon.filter((entry) => entry.captured).length;
 
   if (isLoading) {
@@ -52,19 +56,42 @@ export function Collection() {
       <div className="grid grid-cols-2 gap-3 px-4 py-1 flex-1">
         {pokemon.map((entry) =>
           entry.captured ? (
-            <button
-              type="button"
+            <div
               key={entry.id}
-              className="flex flex-col items-center justify-end gap-1 bg-bg-card rounded-2xl h-32 pb-3 cursor-pointer overflow-hidden border-none text-text-primary hover:bg-bg-hover"
-              onClick={() => void navigate(`/collection/${entry.id}`)}
+              className={
+                entry.id === activeId
+                  ? "flex flex-col items-center justify-end gap-1 rounded-2xl h-32 pb-3 overflow-hidden relative bg-bg-card border-2 border-yellow-400"
+                  : "flex flex-col items-center justify-end gap-1 rounded-2xl h-32 pb-3 overflow-hidden relative bg-bg-card border-2 border-transparent"
+              }
             >
-              <div className="flex-1 flex items-center justify-center w-full overflow-hidden">
-                {entry.image ? (
-                  <img src={entry.image} alt={entry.name} className="w-full h-20 object-cover" />
-                ) : null}
-              </div>
-              <span className="text-xs font-semibold">{entry.name}</span>
-            </button>
+              {entry.id === activeId && (
+                <span className="absolute top-1 right-2 text-yellow-400 text-xs font-bold">✓</span>
+              )}
+              <button
+                type="button"
+                className="flex-1 flex flex-col items-center justify-end w-full cursor-pointer bg-transparent border-none text-text-primary hover:bg-bg-hover rounded-t-2xl"
+                onClick={() => void navigate(`/collection/${entry.id}`)}
+              >
+                <div className="flex-1 flex items-center justify-center w-full overflow-hidden">
+                  {entry.image ? (
+                    <img src={entry.image} alt={entry.name} className="w-full h-16 object-cover" />
+                  ) : null}
+                </div>
+                <span className="text-xs font-semibold">{entry.name}</span>
+              </button>
+              {entry.id !== activeId && (
+                <button
+                  type="button"
+                  className="text-xs bg-accent text-white rounded-full px-3 py-0.5 border-none cursor-pointer mt-1 disabled:opacity-50"
+                  disabled={setActiveMutation.isPending}
+                  onClick={() => void setActiveMutation.mutate(entry.id)}
+                >
+                  {setActiveMutation.isPending && setActiveMutation.variables === entry.id
+                    ? "..."
+                    : "SELECT"}
+                </button>
+              )}
+            </div>
           ) : (
             <div
               key={entry.id}

--- a/frontend/src/features/showcase/components/home.tsx
+++ b/frontend/src/features/showcase/components/home.tsx
@@ -1,10 +1,16 @@
 import "../../../styles/global.css";
+import { useActivePokemon } from "../hooks/use-active-pokemon";
 import { useOpenRaids } from "../hooks/use-open-raids";
 import { RaidCard } from "./ui/raid-card";
 import { TabBar } from "./ui/tab-bar";
 
 export function Home() {
   const { raids, isLoading, error } = useOpenRaids();
+  const { activePokemon } = useActivePokemon();
+
+  const pokemonName = activePokemon?.name ?? "???";
+  const pokemonImage = activePokemon?.image ?? "/images/capture-python.png";
+  const pokemonType = activePokemon?.types[0] ?? "-";
 
   return (
     <div className="showcase-screen">
@@ -24,12 +30,12 @@ export function Home() {
         style={{ background: "radial-gradient(circle, var(--color-accent-glow), transparent)" }}
       >
         <img
-          src="/images/capture-python.png"
-          alt="Python"
+          src={pokemonImage}
+          alt={pokemonName}
           className="w-[200px] h-[200px] rounded-full object-cover"
         />
-        <h1 className="text-2xl font-bold text-text-primary m-0">Python</h1>
-        <p className="text-sm text-text-secondary m-0">Dynamic / Interpreted</p>
+        <h1 className="text-2xl font-bold text-text-primary m-0">{pokemonName}</h1>
+        <p className="text-sm text-text-secondary m-0">{pokemonType}</p>
       </section>
 
       <section className="flex flex-col gap-3 px-6">

--- a/frontend/src/features/showcase/hooks/use-active-pokemon.ts
+++ b/frontend/src/features/showcase/hooks/use-active-pokemon.ts
@@ -1,0 +1,43 @@
+import { useQuery } from "@connectrpc/connect-query";
+import { getActivePokemon } from "../../../gen/lobby/v1/lobby-LobbyService_connectquery";
+import { listPokemon } from "../../../gen/masterdata/v1/masterdata-MasterdataService_connectquery";
+import { useAuthContext } from "../../../lib/auth";
+import { adaptPokemonToUi } from "../api/pokemon";
+import type { Pokemon } from "../types";
+
+export function useActivePokemon() {
+  const { user } = useAuthContext();
+  const userId = user?.id ?? "";
+
+  const activePokemonQuery = useQuery(getActivePokemon, { userId }, { enabled: !!userId });
+  const pokemonListQuery = useQuery(listPokemon, {});
+
+  const activeId = activePokemonQuery.data?.pokemonId ?? null;
+
+  const activePokemon: Pokemon | null = (() => {
+    if (!activeId || !pokemonListQuery.data) {
+      return null;
+    }
+    const index = pokemonListQuery.data.pokemon.findIndex((p) => p.id === activeId);
+    if (index < 0) {
+      return null;
+    }
+    return adaptPokemonToUi(pokemonListQuery.data.pokemon[index], index);
+  })();
+
+  const error =
+    activePokemonQuery.error instanceof Error
+      ? activePokemonQuery.error
+      : pokemonListQuery.error instanceof Error
+        ? pokemonListQuery.error
+        : activePokemonQuery.error || pokemonListQuery.error
+          ? new Error("アクティブポケモン取得失敗")
+          : null;
+
+  return {
+    activePokemon,
+    activeId,
+    isLoading: activePokemonQuery.isPending || pokemonListQuery.isPending,
+    error,
+  };
+}

--- a/frontend/src/features/showcase/hooks/use-set-active-pokemon.ts
+++ b/frontend/src/features/showcase/hooks/use-set-active-pokemon.ts
@@ -1,0 +1,32 @@
+import { createClient } from "@connectrpc/connect";
+import { useTransport } from "@connectrpc/connect-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { LobbyService } from "../../../gen/lobby/v1/lobby_pb";
+import { useAuthContext } from "../../../lib/auth";
+
+export function useSetActivePokemon() {
+  const transport = useTransport();
+  const { user } = useAuthContext();
+  const client = useMemo(() => createClient(LobbyService, transport), [transport]);
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (pokemonId: string) => {
+      if (!user?.id) {
+        throw new Error("User not authenticated");
+      }
+      return client.setActivePokemon(
+        { userId: user.id, pokemonId },
+        {
+          headers: new Headers({
+            "idempotency-key": crypto.randomUUID(),
+          }),
+        },
+      );
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries();
+    },
+  });
+}

--- a/frontend/src/testing/handlers.ts
+++ b/frontend/src/testing/handlers.ts
@@ -123,6 +123,8 @@ const mockItems = [
   },
 ];
 
+let mockActivePokemonId = "1";
+
 const mockInventoryByUser: Record<
   string,
   Array<{ itemId: string; quantity: number; status: string }>
@@ -162,6 +164,34 @@ function pickNumber(body: unknown, keys: string[]): number | null {
 }
 
 export const handlers = [
+  http.post(`${baseUrl}/lobby.v1.LobbyService/GetActivePokemon`, () => {
+    return HttpResponse.json({ pokemonId: mockActivePokemonId });
+  }),
+
+  http.post(`${baseUrl}/lobby.v1.LobbyService/SetActivePokemon`, async ({ request }) => {
+    const body = await request.json();
+    const pokemonId = pickString(body, ["pokemonId", "pokemon_id"]);
+
+    if (!pokemonId) {
+      return HttpResponse.json(
+        { code: "invalid_argument", message: "pokemon_id is required" },
+        { status: 400 },
+      );
+    }
+
+    const exists = mockPokemon.some((p) => p.id === pokemonId);
+    if (!exists) {
+      return HttpResponse.json(
+        { code: "not_found", message: "pokemon not found" },
+        { status: 404 },
+      );
+    }
+
+    mockActivePokemonId = pokemonId;
+    return HttpResponse.json({ success: true });
+  }),
+
+
   http.post(`${baseUrl}/gateway.v1.GatewayService/InvokeCustom`, async ({ request }) => {
     const body = (await request.json()) as { name?: string };
     const name = body.name || "World";


### PR DESCRIPTION
Closes #166

手持ちポケモンの切り替えUIを実装。

Generated with [Claude Code](https://claude.ai/code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hackz-megalo-cup/microservices-app/pull/188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
